### PR TITLE
Update wrtc to latest to work with io.js v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "webtorrent": "0.x",
-    "wrtc": "0.0.55"
+    "wrtc": "0.0.56"
   },
   "devDependencies": {
     "standard": "^4.2.0"


### PR DESCRIPTION
If you try to install with io.js v2.2.1 it will fail.

```
In file included from ../node_modules/nan/nan_new.h:190:
../node_modules/nan/nan_implementation_12_inl.h:181:66: error: too many arguments to function call, expected at
      most 2, have 4
  return v8::Signature::New(v8::Isolate::GetCurrent(), receiver, argc, argv);
         ~~~~~~~~~~~~~~~~~~                                      ^~~~~~~~~~
/Users/kevinsimper/.node-gyp/2.2.1/deps/v8/include/v8.h:4188:3: note: 'New' declared here
  static Local<Signature> New(
  ^
1 error generated.
```

But they upgraded nan in version 0.0.56
